### PR TITLE
Integration of the docker role

### DIFF
--- a/provisioners/ansible/gemini-master.yml
+++ b/provisioners/ansible/gemini-master.yml
@@ -9,9 +9,11 @@
     - tftp
     - httpd
     - coreos-cloudinit
+    - docker
   tags:
     - ansible-controller
     - dnsmasq
     - tftp
     - httpd
     - coreos-cloudinit
+    - docker

--- a/provisioners/ansible/group_vars/all.yml
+++ b/provisioners/ansible/group_vars/all.yml
@@ -4,6 +4,9 @@
 # for password unless ansible_sudo_pass is set
 ansible_ssh_user: my_gemini_master_user
 
+# Account name to be used for interacting with docke
+docker_users: [my_gemini_master_user]
+
 # DNS Domain to use for PXE nodes
 dnsmasq_domain: 'example.com'
 

--- a/provisioners/ansible/pre-setup.sh
+++ b/provisioners/ansible/pre-setup.sh
@@ -15,6 +15,10 @@ git clone -b pxe_coreos https://github.com/gemini-project/ansible-role-httpd.git
 git clone -b pxe_coreos https://github.com/gemini-project/ansible-role-tftp.git ${base_dir}/tftp
 git clone -b pxe_coreos https://github.com/gemini-project/ansible-dnsmasq.git ${base_dir}/dnsmasq
 git clone -b pxe_coreos https://github.com/gemini-project/ansible-coreos-cloudinit.git ${base_dir}/coreos-cloudinit
+git clone https://github.com/gemini-project/ansible-role-docker.git ${base_dir}/docker
+
+cd ${base_dir}/docker && git checkout 6fbe4eaeb1684ed3671cf1a2e7b37ad3eaefc71a 
+
 
 # Show the populated roles directory
 echo "-> These are your Ansible roles"

--- a/vagrant/provision_scripts/build.sh
+++ b/vagrant/provision_scripts/build.sh
@@ -2,10 +2,13 @@
 
 gem_ansible_dir=~/gemini-ansible/provisioners/ansible
 
-git clone https://github.com/gemini-project/gemini-ansible.git && cd $gem_ansible_dir 
+git clone https://github.com/gemini-project/gemini-ansible.git && cd $gem_ansible_dir
 
 #Sets the ssh user name
 sed -i "s/ansible_ssh_user: my_gemini_master_user/ansible_ssh_user: vagrant/" group_vars/all.yml
+
+#Sets docker user
+sed -i "s/docker_users: \[my_gemini_master_user\]/docker_users: \[vagrant\]/" group_vars/all.yml
 
 #removes the option router for the intnet, we only need one default gateway
 sed -i "s/dnsmasq_option_router: '10.10.10.1'/#dnsmasq_option_router: '10.10.10.1'/" group_vars/all.yml


### PR DESCRIPTION
installs docker on the gem-master via dochang's docker role on ansible-galaxy. Pulls his repo and checksout [here] (https://github.com/gemini-project/ansible-role-docker/commit/6fbe4eaeb1684ed3671cf1a2e7b37ad3eaefc71a) to avoid adding regex_escape in the [next commit] (https://github.com/gemini-project/ansible-role-docker/commit/6b8a1c6e1f8de4b70439872385d17b5133ebbe28)

This is one ugly recommendation, will be submitting another PR that installs docker by leveraging [contrib/ansible/roles/docker] (https://github.com/kubernetes/contrib/tree/master/ansible/roles/docker)